### PR TITLE
adds getStateHeirarchy() to StateMachine<S, E> interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -72,6 +72,7 @@ export interface Configuration<S, E> {
 
 export interface StateMachine<S, E> {
   getCurrentState(): S;
+  getStateHierarchy(): S[];
   canHandle(event: E, eventPayload?: any): boolean;
   handle(event: E, eventPayload?: any): StateMachine<S, E>;
 }


### PR DESCRIPTION
fixes #29 